### PR TITLE
[LPT] ScaleShift dim < 4 only dequantization conversion

### DIFF
--- a/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
+++ b/inference-engine/src/transformations/src/transformations/convert_opset1_to_legacy/convert_mul_add_to_scaleshift_or_power.cpp
@@ -137,14 +137,13 @@ void ngraph::pass::ConvertMulAddToScaleShiftOrPower::convert_mul_add_to_scaleshi
         const auto output_shape = add_node->get_output_partial_shape(0);
         const auto output_shape_rank = output_shape.rank().get_length();
 
+        bool is_dequantization =
+                (add_node->get_rt_info().count("DEQUANTIZATION") != 0 || mul_node->get_rt_info().count("DEQUANTIZATION") != 0);
+
         if (res1 == CONVERSION_RESULT::NONE || res2 == CONVERSION_RESULT::NONE ||
-            ((res1 == CONVERSION_RESULT::SCALE_SHIFT || res2 == CONVERSION_RESULT::SCALE_SHIFT) &&
-            (output_shape_rank == 1 || output_shape_rank > 4))) {
+            ((res1 == CONVERSION_RESULT::SCALE_SHIFT || res2 == CONVERSION_RESULT::SCALE_SHIFT) && !is_dequantization && output_shape_rank < 4)) {
             return false;
         }
-
-        bool is_dequantization =
-            (add_node->get_rt_info().count("DEQUANTIZATION") != 0 || mul_node->get_rt_info().count("DEQUANTIZATION") != 0);
 
         // TODO: in case if scale and shift constants has equal values the best way is to convert them to Power
         if (res1 == CONVERSION_RESULT::SCALE_SHIFT || res2 == CONVERSION_RESULT::SCALE_SHIFT || is_dequantization) {


### PR DESCRIPTION
Fix for GNA tests

It reverts Legacy transformations behavior for Eltwise layers that are not Dequantizations.